### PR TITLE
Phase 3: hourly expiration sweep (calls broccoli-api internal.expireItems)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import passport from "passport";
 import { HeaderAPIKeyStrategy } from "passport-headerapikey";
 import handleDailyReport from "./workers/handleDailyReport";
 import handleItemRemove from "./workers/handleItemRemove";
+import expireCoreItems from "./workers/expireCoreItems";
 import prisma from "./repository/prisma";
 import logger from "./utils/logger";
 import dayjs from "dayjs";
@@ -311,6 +312,19 @@ const authMiddleware = () =>
         timezone: "America/Chicago",
       },
     );
+    // Phase 3 expiration sweep (core PRD §7): hourly, on the quarter hour so
+    // it doesn't collide with the daily-reports run. Direct call, no queue —
+    // it's one idempotent HTTP request and the next hour self-heals a miss.
+    cron.schedule("15 * * * *", async () => {
+      try {
+        const expired = await expireCoreItems();
+        if (expired > 0) {
+          logger.info(`expiration sweep: ${expired} item(s) marked EXPIRED`);
+        }
+      } catch (err) {
+        logger.error("expiration sweep failed", err);
+      }
+    });
   } catch (e) {
     logger.error("error on startup:", e);
   }

--- a/src/workers/expireCoreItems.ts
+++ b/src/workers/expireCoreItems.ts
@@ -1,0 +1,33 @@
+import logger from "../utils/logger";
+
+// Phase 3 (core PRD §7): ask broccoli-api to flip ACTIVE items past their
+// expiration date to EXPIRED. The api owns the schema and is the single DB
+// writer, so this goes over its token-gated internal tRPC surface rather
+// than touching Postgres directly (PRD §4). Idempotent — a missed run is
+// caught by the next one.
+export default async function expireCoreItems(): Promise<number> {
+  const url = process.env.CORE_API_URL;
+  const token = process.env.CORE_API_TOKEN;
+  if (!url || !token) {
+    logger.warn(
+      "expireCoreItems skipped: CORE_API_URL / CORE_API_TOKEN not configured",
+    );
+    return 0;
+  }
+
+  const res = await fetch(`${url}/trpc/internal.expireItems`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-service-token": token,
+    },
+    body: "{}",
+  });
+  if (!res.ok) {
+    throw new Error(`internal.expireItems failed: ${res.status}`);
+  }
+  const json = (await res.json()) as {
+    result: { data: { expired: number } };
+  };
+  return json.result.data.expired;
+}


### PR DESCRIPTION
The scheduler leg of core Phase 3 (PRD §7 — 'scheduler transitions item statuses over time').

## What
- New `expireCoreItems` worker: POSTs to the new api's token-gated `internal.expireItems`, which flips ACTIVE items past their `expiresAt` to `EXPIRED`. The api stays the single DB writer for the core schema (PRD §4) — this service never touches that Postgres directly.
- Hourly cron at `:15` (offset from the 10:30 daily-reports run). Direct call, no BullMQ queue: it's one idempotent request and the next hour self-heals a miss.
- **Degrades gracefully**: without `CORE_API_URL`/`CORE_API_TOKEN` it logs a warning and no-ops, so nothing changes for the legacy deployment until the vars are set.

## Verified
Ran the actual worker module against a local broccoli-api: past-due item → `expired=1`, DB shows `EXPIRED`.

## ⚠️ Deploy needs two Railway vars on the scheduler service
- `CORE_API_URL=https://broccoli-api-production.up.railway.app` (public URL — the api binds IPv4, so private networking won't reach it)
- `CORE_API_TOKEN` = the same value as broccoli-api's `INTERNAL_SERVICE_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)