### PR TITLE
Phase 4: hourly nudge tick (calls broccoli-api internal.sendNudges)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import { HeaderAPIKeyStrategy } from "passport-headerapikey";
 import handleDailyReport from "./workers/handleDailyReport";
 import handleItemRemove from "./workers/handleItemRemove";
 import expireCoreItems from "./workers/expireCoreItems";
+import sendCoreNudges from "./workers/sendCoreNudges";
 import prisma from "./repository/prisma";
 import logger from "./utils/logger";
 import dayjs from "dayjs";
@@ -323,6 +324,22 @@ const authMiddleware = () =>
         }
       } catch (err) {
         logger.error("expiration sweep failed", err);
+      }
+    });
+    // Phase 4 nudge tick (core PRD §7): hourly at :20, right after the expiry
+    // sweep so freshly-EXPIRED items make it into the day's nudge. The api
+    // decides who's eligible (quiet hours, one nudge per local day) — the
+    // hourly tick just means each user is nudged at the first eligible hour.
+    cron.schedule("20 * * * *", async () => {
+      try {
+        const result = await sendCoreNudges();
+        if (result && result.usersNudged > 0) {
+          logger.info(
+            `nudge tick: ${result.usersNudged} user(s) nudged, ${result.messagesSent} message(s), ${result.tokensPruned} token(s) pruned`,
+          );
+        }
+      } catch (err) {
+        logger.error("nudge tick failed", err);
       }
     });
   } catch (e) {

--- a/src/workers/sendCoreNudges.ts
+++ b/src/workers/sendCoreNudges.ts
@@ -1,0 +1,38 @@
+import logger from "../utils/logger";
+
+// Phase 4 (core PRD §7): ask broccoli-api to send the day's grouped push
+// nudges to whoever is eligible right now — the api owns eligibility (quiet
+// hours, once per local day) and delivery (Expo Push API); this service is
+// just the clock, same shape as expireCoreItems.
+export default async function sendCoreNudges(): Promise<{
+  usersNudged: number;
+  messagesSent: number;
+  tokensPruned: number;
+} | null> {
+  const url = process.env.CORE_API_URL;
+  const token = process.env.CORE_API_TOKEN;
+  if (!url || !token) {
+    logger.warn(
+      "sendCoreNudges skipped: CORE_API_URL / CORE_API_TOKEN not configured",
+    );
+    return null;
+  }
+
+  const res = await fetch(`${url}/trpc/internal.sendNudges`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-service-token": token,
+    },
+    body: "{}",
+  });
+  if (!res.ok) {
+    throw new Error(`internal.sendNudges failed: ${res.status}`);
+  }
+  const json = (await res.json()) as {
+    result: {
+      data: { usersNudged: number; messagesSent: number; tokensPruned: number };
+    };
+  };
+  return json.result.data;
+}


### PR DESCRIPTION
Scheduler leg of Phase 4 (pairs with broccoli/#21).

- Hourly cron at **:20** — deliberately right after the :15 expiry sweep, so freshly-EXPIRED items are included in the day's nudge
- The api owns eligibility (quiet hours, one grouped nudge per local day) and delivery (Expo Push API); this stays a dumb clock like the expiry sweep
- No-ops with a warning when `CORE_API_URL`/`CORE_API_TOKEN` are unset

Uses the **same two Railway vars** as the expiry sweep — already configured, nothing new to set.

Verified against a local broccoli-api: tick round-trips `{usersNudged, messagesSent, tokensPruned}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)