### PR TITLE
Add 5-minute meal-window tick (internal.sendMealNudges)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import express from "express";
 import cron from "node-cron";
 import expireCoreItems from "./workers/expireCoreItems";
 import sendCoreNudges from "./workers/sendCoreNudges";
+import sendCoreMealNudges from "./workers/sendMealNudges";
 import logger from "./utils/logger";
 
 dotenv.config();
@@ -50,5 +51,22 @@ cron.schedule("20 * * * *", async () => {
     }
   } catch (err) {
     logger.error("nudge tick failed", err);
+  }
+});
+
+// Meal-window tick (PRD Pillar 4): every 5 minutes so meal prompts land
+// within ±5 min of the user's chosen time. The api decides which windows are
+// due (per-day-of-week, idempotent per local day) — this is just the clock,
+// same shape as the hourly nudges above.
+cron.schedule("*/5 * * * *", async () => {
+  try {
+    const result = await sendCoreMealNudges();
+    if (result && result.mealsFired > 0) {
+      logger.info(
+        `meal tick: ${result.mealsFired} meal(s) fired, ${result.messagesSent} message(s), ${result.tokensPruned} token(s) pruned`,
+      );
+    }
+  } catch (err) {
+    logger.error("meal tick failed", err);
   }
 });

--- a/src/workers/sendMealNudges.ts
+++ b/src/workers/sendMealNudges.ts
@@ -1,0 +1,34 @@
+import logger from "../utils/logger";
+
+export default async function sendCoreMealNudges(): Promise<{
+  mealsFired: number;
+  messagesSent: number;
+  tokensPruned: number;
+} | null> {
+  const url = process.env.CORE_API_URL;
+  const token = process.env.CORE_API_TOKEN;
+  if (!url || !token) {
+    logger.warn(
+      "sendCoreMealNudges skipped: CORE_API_URL / CORE_API_TOKEN not configured",
+    );
+    return null;
+  }
+
+  const res = await fetch(`${url}/trpc/internal.sendMealNudges`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-service-token": token,
+    },
+    body: "{}",
+  });
+  if (!res.ok) {
+    throw new Error(`internal.sendMealNudges failed: ${res.status}`);
+  }
+  const json = (await res.json()) as {
+    result: {
+      data: { mealsFired: number; messagesSent: number; tokensPruned: number };
+    };
+  };
+  return json.result.data;
+}


### PR DESCRIPTION
## What

Adds the clock side of meal-window notifications: a 5-minute cron calling broccoli-api's new `internal.sendMealNudges`, so meal prompts land within ±5 min of the user's chosen time. The api owns eligibility (per-day-of-week, idempotent per local day via `MealWindow.lastSentAt`) — this service stays just the clock.

Pairs with the api/mobile PR in Afrothundr/broccoli.
